### PR TITLE
#26 Patching PHP cookbook to detect PEAR version for retrieving the PECL extensions directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 
 all: development
 
+apply-patches:
+	# Add version detection for retrieving the extensions directory for PECL
+	# since PEAR < 1.10.0 doesn't use the configured ext_dir. @see http://pear.php.net/bugs/bug.php?id=18666
+	patch -d cookbooks/berks-cookbooks/php -p1 < cookbooks/patches/opscode_php-PECL_version_detection.patch
+
 development: install-gems
 
 install-gems:
@@ -10,10 +15,12 @@ install-gems:
 install-vendor-cookbooks:
 	if [ ! -d "cookbooks/berks-cookbooks" ]; then \
 		cd cookbooks && bundle exec berks vendor ;\
+		cd .. && $(MAKE) apply-patches ;\
 	fi
 
 refresh-vendor-cookbooks: delete-vendor-cookbooks
-	cd cookbooks && bundle exec berks update && bundle exec berks vendor
+	cd cookbooks && bundle exec berks update && bundle exec berks vendor ;\
+	cd .. && $(MAKE) apply-patches ;\
 
 delete-vendor-cookbooks:
 	rm -r cookbooks/berks-cookbooks

--- a/cookbooks/berks-cookbooks/php/providers/pear.rb
+++ b/cookbooks/berks-cookbooks/php/providers/pear.rb
@@ -191,9 +191,12 @@ end
 
 def get_extension_dir
   @extension_dir ||= begin
-                       # Consider using "pecl config-get ext_dir". It is more cross-platform.
-                       # p = shell_out("php-config --extension-dir")
-                       p = shell_out("#{node['php']['pecl']} config-get ext_dir")
+                       pecl_version_match = shell_out("#{node['php']['pecl']} version").stdout.match('PEAR Version: ([\d?\.?]+)')
+                       if !pecl_version_match[1].nil? && Gem::Version.new(pecl_version_match[1]) < Gem::Version.new('1.10.0')
+                         p = shell_out('php-config --extension-dir')
+                       else
+                         p = shell_out("#{node['php']['pecl']} config-get ext_dir")
+                       end
                        p.stdout.strip
                      end
 end

--- a/cookbooks/patches/opscode_php-PECL_version_detection.patch
+++ b/cookbooks/patches/opscode_php-PECL_version_detection.patch
@@ -1,0 +1,20 @@
+diff --git a/providers/pear.rb b/providers/pear.rb
+index ae5a63d..9ca4d32 100644
+--- a/providers/pear.rb
++++ b/providers/pear.rb
+@@ -191,9 +191,12 @@ end
+ 
+ def get_extension_dir
+   @extension_dir ||= begin
+-                       # Consider using "pecl config-get ext_dir". It is more cross-platform.
+-                       # p = shell_out("php-config --extension-dir")
+-                       p = shell_out("#{node['php']['pecl']} config-get ext_dir")
++                       pecl_version_match = shell_out("#{node['php']['pecl']} version").stdout.match('PEAR Version: ([\d?\.?]+)')
++                       if !pecl_version_match[1].nil? && Gem::Version.new(pecl_version_match[1]) < Gem::Version.new('1.10.0')
++                         p = shell_out('php-config --extension-dir')
++                       else
++                         p = shell_out("#{node['php']['pecl']} config-get ext_dir")
++                       end
+                        p.stdout.strip
+                      end
+ end


### PR DESCRIPTION
We have patched the opscode php cookbook to use the different method of retrieving the PECL extensions directory and creating a way to maintain patches via make.
