### PR TITLE
#21 Creating ApacheSolr specific utiliy recipe and Drupal ApacheSolr specific recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ What's in the stack?
 Component     | Version(s)                  | Notes
 ------------- | --------------------------- | -------------
 Apache2       | 2.2                         |
-ApacheSolr    | tbd                         | Coming soon
+ApacheSolr    | 3.x(default) & 4.x          |
 APC           | 3.1.7                       |
 Box OS        | Ubuntu 12.04                |
 Chef Solo     | 10.14.2                     |

--- a/config.dstack.yml
+++ b/config.dstack.yml
@@ -29,9 +29,13 @@ chef:
     - avahi
     - default-web
     - drupal
+#    - drupal::solr
     - utils::dev-tools
     - utils::scripts
     - utils::xdebug
+#  drupal:
+#    solr:
+#      module_path: /home/vagrant/docroot/sites/all/modules/contrib/apachesolr
 # Overriding recipe attributes.
 #  lamp:
 #    php:

--- a/cookbooks/local-cookbooks/drupal/attributes/solr.rb
+++ b/cookbooks/local-cookbooks/drupal/attributes/solr.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook Name:: drupal
+# Attributes:: solr
+#
+# Copyright 2014 dStack Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_attribute 'hipsnip-solr'
+
+default['drupal']['solr']['module_path'] = ''
+
+if node['solr']['version'].start_with?('4')
+  default['drupal']['solr']['apachesolr_conf_dir'] = 'collection1/conf'
+  default['drupal']['solr']['module_conf_dir'] = 'solr-conf/solr-4.x'
+else
+  default['drupal']['solr']['apachesolr_conf_dir'] = 'conf'
+  default['drupal']['solr']['module_conf_dir'] = 'solr-conf/solr-3.x'
+end
+
+default['drupal']['solr']['module_conf_files'] = [
+  'protwords.txt',
+  'schema.xml',
+  'schema_extra_fields.xml',
+  'schema_extra_types.xml',
+  'solrconfig.xml',
+  'solrconfig_extra.xml',
+  'solrcore.properties'
+]

--- a/cookbooks/local-cookbooks/drupal/metadata.rb
+++ b/cookbooks/local-cookbooks/drupal/metadata.rb
@@ -5,4 +5,5 @@ license          "Apache 2.0"
 description      "Configures web site."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1.0"
+depends          "hipsnip-solr"
 depends          "php"

--- a/cookbooks/local-cookbooks/drupal/recipes/solr.rb
+++ b/cookbooks/local-cookbooks/drupal/recipes/solr.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: drupal
+# Recipe:: solr
+#
+# Copyright 2014 dStack Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'utils::solr'
+
+module_conf_dir = node['drupal']['solr']['module_conf_dir']
+apachesolr_conf_dir = node['drupal']['solr']['apachesolr_conf_dir']
+
+if node['drupal']['solr']['module_path'] == ''
+  raise 'Drupal ApacheSolr module directory has not be set.'
+elsif !File.directory? node['drupal']['solr']['module_path']
+  raise 'Unable to locate the Drupal ApacheSolr module directory. Please check the path.'
+end
+
+# Copy the Drupal ApacheSolr conf files to the ApacheSolr conf directory.
+node['drupal']['solr']['module_conf_files'].each do |config_file|
+  file "#{node['solr']['home']}/#{apachesolr_conf_dir}/#{config_file}" do
+    content IO.read("#{node['drupal']['solr']['module_path']}/#{module_conf_dir}/#{config_file}")
+    notifies :restart, 'service[jetty]'
+  end
+end

--- a/cookbooks/local-cookbooks/utils/attributes/solr.rb
+++ b/cookbooks/local-cookbooks/utils/attributes/solr.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: utils
+# Attributes:: default
+#
+# Copyright 2014 dStack Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_attribute "java"
+include_attribute "hipsnip-solr"
+include_attribute "hipsnip-jetty"
+
+node['jetty']['port'] = 8983
+
+if node['solr']['version'].start_with?('4')
+  node['java']['jdk_version'] = '7'
+  node['jetty']['version'] = '9.0.6.v20130930'
+  node['jetty']['link'] = 'http://eclipse.org/downloads/download.php?file=/jetty/9.0.6.v20130930/dist/jetty-distribution-9.0.6.v20130930.tar.gz&r=1'
+  node['jetty']['checksum'] = 'c35c6c0931299688973e936186a6237b69aee2a7912dfcc2494bde9baeeab58f'
+end

--- a/cookbooks/local-cookbooks/utils/metadata.rb
+++ b/cookbooks/local-cookbooks/utils/metadata.rb
@@ -7,4 +7,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version "0.1.0"
 recipe "utils::dev-tools", "Installs and configures development tools."
 recipe "utils::scripts", "Runs specified scripts at post-install and post-up."
+recipe "utils::solr", "Installs and configures ApacheSolr using Jetty."
 recipe "utils::xdebug", "Installs and configures xdebug."
+depends "hipsnip-solr"

--- a/cookbooks/local-cookbooks/utils/recipes/solr.rb
+++ b/cookbooks/local-cookbooks/utils/recipes/solr.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: utils
+# Recipe:: solr
+#
+# Copyright 2014 dStack Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "hipsnip-solr"
+
+if !node['solr']['version'].start_with?('4') && !node['solr']['version'].start_with?('3')
+  raise 'Only ApacheSolr versions 3.x and 4.x are currently supported.'
+end


### PR DESCRIPTION
You may now enable ApacheSolr by adding "drupal::solr" to the recipe lists

You will need to specify the Drupal ApacheSolr module path for it to install the correct configuration files.

You may also specify the solr version.
